### PR TITLE
Drop support for Python 2.5 and Django 1.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     description='Add Django LogEntries the the Django admin site',
     long_description=open('README.rst').read(),
     install_requires=[
-        'Django >= 1.3',
+        'Django >= 1.4',
     ],
     classifiers=(
         'Development Status :: 3 - Alpha',
@@ -20,7 +20,6 @@ setup(
         'Natural Language :: English',
         'License :: OSI Approved :: ISC License (ISCL)',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.5',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
     ),


### PR DESCRIPTION
They are no longer receiving security patches, so it is irresponsible to support them.
