### PR TITLE
Avoid using get_all_field_names() method

### DIFF
--- a/logentry_admin/admin.py
+++ b/logentry_admin/admin.py
@@ -48,7 +48,7 @@ class UserListFilter(admin.SimpleListFilter):
 class LogEntryAdmin(admin.ModelAdmin):
     date_hierarchy = 'action_time'
 
-    readonly_fields = (LogEntry._meta.get_all_field_names() +
+    readonly_fields = ([f.name for f in LogEntry._meta.fields] +
                        ['object_link', 'action_description', 'user_link'])
 
     fieldsets = (


### PR DESCRIPTION
In Django 1.7 (and maybe earlier), running `makemigrations` fails since `._meta.get_all_field_names()` returns `content_type_id` (as well as `content_type`), and then building the form fails since this extra field does not resolve to a model field.
