### PR TITLE
Compliant with Django1.8 deprecation warnings

### DIFF
--- a/logentry_admin/admin.py
+++ b/logentry_admin/admin.py
@@ -147,8 +147,8 @@ class LogEntryAdmin(admin.ModelAdmin):
     user_link.admin_order_field = 'user'
     user_link.short_description = 'user'
 
-    def queryset(self, request):
-        queryset = super(LogEntryAdmin, self).queryset(request)
+    def get_queryset(self, request):
+        queryset = super(LogEntryAdmin, self).get_queryset(request)
         return queryset.prefetch_related('content_type')
 
     def get_actions(self, request):


### PR DESCRIPTION
It is a minor change to be compliant with upcoming Django 1.8 (deprecation warning).

Here is the coveralls (Python 3.4.2/Django 1.7) report for the patch: https://coveralls.io/jobs/3144057

Thanks
