### PR TITLE
Improve test runs, support Python 3.5, Django 1.9, drop support for older versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
     - PYTHONPATH=.
     - DJANGO_SETTINGS_MODULE=test_settings
   matrix:
-    - TOX_ENV=migrations-django17
     - TOX_ENV=py35-django19
     - TOX_ENV=py34-django19
     - TOX_ENV=py27-django19

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,45 +1,28 @@
 language: python
-python:
- - "2.6"
- - "2.7"
- - "3.2"
- - "3.3"
- - "3.4"
+python: 3.5
 env:
   global:
     - PYTHONPATH=.
     - DJANGO_SETTINGS_MODULE=test_settings
   matrix:
-   - DJANGO_VERSION=1.4
-   - DJANGO_VERSION=1.5
-   - DJANGO_VERSION=1.6
-   - DJANGO_VERSION=1.7
-   - DJANGO_VERSION=1.8
-matrix:
-  exclude:
-    - python: "3.2"
-      env: DJANGO_VERSION=1.4
-    - python: "3.3"
-      env: DJANGO_VERSION=1.4
-    - python: "3.4"
-      env: DJANGO_VERSION=1.4
-    - python: "3.4"
-      env: DJANGO_VERSION=1.5
-    - python: "3.4"
-      env: DJANGO_VERSION=1.6
-    - python: "2.6"
-      env: DJANGO_VERSION=1.7
-    - python: "2.6"
-      env: DJANGO_VERSION=1.8
+    - TOX_ENV=migrations-django17
+    - TOX_ENV=py35-django19
+    - TOX_ENV=py34-django19
+    - TOX_ENV=py27-django19
+    - TOX_ENV=py35-django18
+    - TOX_ENV=py34-django18
+    - TOX_ENV=py33-django18
+    - TOX_ENV=py32-django18
+    - TOX_ENV=py27-django18
+    - TOX_ENV=py34-django17
+    - TOX_ENV=py33-django17
+    - TOX_ENV=py32-django17
+    - TOX_ENV=py27-django17
+    - TOX_ENV=coverage
+    - TOX_ENV=flake8
 install:
- - pip install -q "Django>=${DJANGO_VERSION},<${DJANGO_VERSION}.99"
- - pip install -q South==1.0 coverage flake8
- - pip install coveralls
+ - pip install tox coveralls
 script:
-  - django-admin.py syncdb --noinput
-  - django-admin.py migrate --noinput
-  - coverage run --source=logentry_admin `which django-admin.py` test logentry_admin
-  - coverage report --show-missing --fail-under=90
-  - flake8 logentry_admin
+  - tox -e $TOX_ENV
 after_success:
   coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+Current
+=======
+
+* Add tests and support for Django 1.9 and Python 3.5.
+* Drop support for Python 2.5, 2.6, Django 1.4, 1.5, 1.6.
+
+
 v0.1.5 - 17/02/2015
 ===================
 

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,13 @@ Allows to view all log entries in the admin.
 Originally based on: `Django snippet 2484 <http://djangosnippets.org/snippets/2484/>`_
 
 
+Supported versions
+==================
+
+* Django 1.9, 1.8, 1.7
+* Python 3.5, 3.4, 3.3, 3.2, 2.7
+
+
 Installation
 ============
 

--- a/logentry_admin/admin.py
+++ b/logentry_admin/admin.py
@@ -2,18 +2,13 @@ from __future__ import unicode_literals
 
 from django.contrib import admin
 from django.contrib.admin.models import LogEntry, ADDITION, CHANGE, DELETION
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.utils.encoding import force_text
 from django.utils.html import escape
 from django.utils.translation import ugettext_lazy as _
 
-
-try:
-    from django.contrib.auth import get_user_model
-    User = get_user_model()
-except ImportError:
-    from django.contrib.auth.models import User  # noqa
 
 action_names = {
     ADDITION: _('Addition'),
@@ -40,7 +35,7 @@ class UserListFilter(admin.SimpleListFilter):
     parameter_name = 'user'
 
     def lookups(self, request, model_admin):
-        staff = User.objects.filter(is_staff=True)
+        staff = get_user_model().objects.filter(is_staff=True)
         return (
             (s.id, force_text(s))
             for s in staff

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    migrations-django17,
     {py35,py34,py27}-django19,
     {py35,py34,py33,py32,py27}-django18,
     {py34,py33,py32,py27}-django17,
@@ -18,14 +17,10 @@ setenv =
 commands =
     django-admin.py test logentry_admin
 
-
-[testenv:migrations-django17]
-commands = django-admin.py migrate --noinput
-
-
 [testenv:coverage]
 deps = coverage
 commands =
+    django-admin.py migrate --noinput
     coverage run --source=logentry_admin {envbindir}/django-admin.py test logentry_admin
     coverage report --show-missing --fail-under=90
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,123 +1,24 @@
 [tox]
 envlist =
-    py3.4-django1.8, py3.3-django1.8, py3.2-django1.8, py2.7-django1.8,
-    py3.4-django1.7, py3.3-django1.7, py3.2-django1.7, py2.7-django1.7,
-    py3.3-django1.6, py3.2-django1.6, py2.7-django1.6, py2.6-django1.6,
-    py3.3-django1.5, py3.2-django1.5, py2.7-django1.5, py2.6-django1.5,
-    py2.7-django1.4, py2.6-django1.4, py2.5-django1.4,
+    {py34,py33,py32,py27}-{django18,django17},
     coverage, flake8
 
 [testenv]
+deps =
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
 setenv =
     PYTHONPATH = .
     DJANGO_SETTINGS_MODULE=test_settings
-commands=
+commands =
     django-admin.py test logentry_admin
 
 [testenv:coverage]
-deps=coverage
-commands=
+deps = coverage
+commands =
     coverage run --source=logentry_admin {envbindir}/django-admin.py test logentry_admin
     coverage report --show-missing --fail-under=90
 
 [testenv:flake8]
-deps=flake8
+deps = flake8==2.5.1
 commands = flake8 logentry_admin
-
-[testenv:py3.4-django1.8]
-basepython = python3.4
-deps = Django==1.8a1
-
-[testenv:py3.3-django1.8]
-basepython = python3.3
-deps = Django==1.8a1
-
-[testenv:py3.2-django1.8]
-basepython = python3.2
-deps = Django==1.8a1
-
-[testenv:py2.7-django1.8]
-basepython = python2.7
-deps = Django==1.8a1
-
-[testenv:py3.4-django1.7]
-basepython = python3.4
-deps = Django==1.7
-
-[testenv:py3.3-django1.7]
-basepython = python3.3
-deps = Django==1.7
-
-[testenv:py3.2-django1.7]
-basepython = python3.2
-deps = Django==1.7
-
-[testenv:py2.7-django1.7]
-basepython = python2.7
-deps = Django==1.7
-
-[testenv:py3.3-django1.6]
-basepython = python3.3
-deps =
-    Django==1.6.3
-    South==1.0
-
-[testenv:py3.2-django1.6]
-basepython = python3.2
-deps =
-    Django==1.6.3
-    South==1.0
-
-[testenv:py2.7-django1.6]
-basepython = python2.7
-deps =
-    Django==1.6.3
-    South==1.0
-
-[testenv:py2.6-django1.6]
-basepython = python2.6
-deps =
-    Django==1.6.3
-    South==1.0
-
-[testenv:py3.3-django1.5]
-basepython = python3.3
-deps =
-    Django==1.5.6
-    South==1.0
-
-[testenv:py3.2-django1.5]
-basepython = python3.2
-deps =
-    Django==1.5.6
-    South==1.0
-
-[testenv:py2.7-django1.5]
-basepython = python2.7
-deps =
-    Django==1.5.6
-    South==1.0
-
-[testenv:py2.6-django1.5]
-basepython = python2.6
-deps =
-    Django==1.5.6
-    South==1.0
-
-[testenv:py2.7-django1.4]
-basepython = python2.7
-deps =
-    Django==1.4.11
-    South==1.0
-
-[testenv:py2.6-django1.4]
-basepython = python2.6
-deps =
-    Django==1.4.11
-    South==1.0
-
-[testenv:py2.5-django1.4]
-basepython = python2.5
-deps =
-    Django==1.4.11
-    South==1.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,15 @@
 [tox]
 envlist =
-    {py34,py33,py32,py27}-{django18,django17},
+    {py35,py34,py27}-django19,
+    {py35,py34,py33,py32,py27}-django18,
+    {py34,py33,py32,py27}-django17,
     coverage, flake8
 
 [testenv]
 deps =
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
 setenv =
     PYTHONPATH = .
     DJANGO_SETTINGS_MODULE=test_settings

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,11 @@
 [tox]
 envlist =
+    migrations-django17,
     {py35,py34,py27}-django19,
     {py35,py34,py33,py32,py27}-django18,
     {py34,py33,py32,py27}-django17,
-    coverage, flake8
+    coverage,
+    flake8
 
 [testenv]
 deps =
@@ -15,6 +17,11 @@ setenv =
     DJANGO_SETTINGS_MODULE=test_settings
 commands =
     django-admin.py test logentry_admin
+
+
+[testenv:migrations-django17]
+commands = django-admin.py migrate --noinput
+
 
 [testenv:coverage]
 deps = coverage


### PR DESCRIPTION
* Reorganize tox.ini and travis tests.
* Test Django 1.9 support.
* Test Python 3.5 support.
* Drop support for older versions:
  * Python 2.5, 2.6
  * Django 1.4, 1.5, 1.6