### PR TITLE
fixed deprecation warnings

### DIFF
--- a/logentry_admin/admin.py
+++ b/logentry_admin/admin.py
@@ -5,11 +5,16 @@ from django.contrib import admin
 from django.contrib.admin.models import LogEntry, ADDITION, CHANGE, DELETION
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.utils.encoding import force_text
 from django.utils.html import escape
-from django.utils.translation import pgettext_lazy, ugettext_lazy as _
 from django.utils.safestring import mark_safe
+from django.utils.translation import pgettext_lazy
 
+if django.VERSION[0] < 2:
+    from django.utils.encoding import force_text as force_str
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.encoding import force_str
+    from django.utils.translation import gettext_lazy as _
 
 try:
     from django.urls import reverse, NoReverseMatch
@@ -44,7 +49,7 @@ class UserListFilter(admin.SimpleListFilter):
     def lookups(self, request, model_admin):
         staff = get_user_model().objects.filter(is_staff=True)
         return (
-            (s.id, force_text(s))
+            (s.id, force_str(s))
             for s in staff
         )
 
@@ -138,7 +143,7 @@ class LogEntryAdmin(admin.ModelAdmin):
 
     def user_link(self, obj):
         content_type = ContentType.objects.get_for_model(type(obj.user))
-        user_link = escape(force_text(obj.user))
+        user_link = escape(force_str(obj.user))
         try:
             # try returning an actual link instead of object repr string
             url = reverse(

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,7 +1,10 @@
-from django.conf.urls import url
 from django.contrib import admin
 
+try:
+    from django.urls import re_path
+except ImportError:
+    from django.conf.urls import url as re_path
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^admin/', admin.site.urls),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
 envlist =
+    {py38,py37,py36}-django31,
     {py38,py37,py36}-django30,
-    {py37,py36,py35}-django22,
+    {py38,py37,py36,py35}-django22,
     {py37,py36,py35}-django21,
     {py37,py36,py35,py34}-django20,
-    {py36,py35,py34,py27}-{django111,django110,django19},
-    {py35,py34,py27}-django18,
+    {py37,py36,py35,py34,py27}-{django111},
+    {py35,py34,py27}-{django110,django19,django18},
     py36-flake8
 
 [testenv]
@@ -17,6 +18,7 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
     coverage
     pytest
     pytest-cov


### PR DESCRIPTION
Multiple deprecation warnings fixed, while still maintaining compatibility with the targeted django and python versions.

* `django.utils.translation.ugettext_lazy`: it has been an alias for `django.utils.translation.gettext_lazy` [since django 2.0](https://github.com/django/django/blob/2.0.13/django/utils/translation/__init__.py#L81), and deprecated [since django 3.0](https://github.com/django/django/blob/3.0.10/django/utils/translation/__init__.py#L95). However, it should still be used for django 1.X.
* `django.utils.encoding.force_text`: it has been an alias for `django.utils.encoding.force_str` [since django 2.0](https://github.com/django/django/blob/2.0.13/django/utils/encoding.py#L109), and deprecated [since django 3.0](https://github.com/django/django/blob/3.0.10/django/utils/encoding.py#L110). However, it should still be used for django 1.X.
* `django.conf.urls.url`: it has been an alias for `django.urls.re_path` [since django 2.0](https://github.com/django/django/blob/2.0.13/django/conf/urls/__init__.py#L12), and deprecated [since django 3.1](https://github.com/django/django/blob/3.1.2/django/conf/urls/__init__.py#L15). It is not available in django 1.X

Also updated tested versions in tox.ini:

* added tests for Django 3.1
* updated tested python versions for django 2.2 to match the versions listed in the [release notes](https://docs.djangoproject.com/en/3.1/releases/2.2/)
* same for [django 1.11](https://docs.djangoproject.com/en/3.1/releases/1.11/), [django 1.10](https://docs.djangoproject.com/en/3.1/releases/1.10/) and [django 1.9](https://docs.djangoproject.com/en/3.1/releases/1.9/)
