### PR TITLE
Add missing dependency for Django 2.2. to fix failing Travis tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ v1.0.7 - Unreleased
 ===================
 
 * Add tests for Django 3.1.
+* Fix failing tests for Django 2.2.
 
 
 v1.0.6 - 23/04/2020

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
     coverage


### PR DESCRIPTION
Fixes #61 

There was a missing dependency in the `tox.ini` file for `django22`, meaning when tox tried to run the tests for enviornment `{py38,py37,py36,py35}-django22`, instead of testing against Django 2.2, it was actually testing against the latest release, Django 3.2, and failing.

This PR/fix adds the missing dependency.