### PR TITLE
Add tests for py39-django32 & fix failing py36-flake8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ jobs:
     - python: 3.8
       dist: xenial
       sudo: true
+    - python: 3.9
+      dist: xenial
+      sudo: true
 
 install:
   - pip install -U packaging  # fix for Python3.4 build

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ v1.0.7 - Unreleased
 ===================
 
 * Add tests for Django 3.1.
+* Fix failing tests for Django 2.2.
 
 
 v1.0.6 - 23/04/2020

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,10 @@ v1.0.7 - Unreleased
 ===================
 
 * Add tests for Django 3.1.
+* Add tests for Django 3.2 LTS.
+* Test on Python 3.9 (for Django versions 2.2 LTS to present (3.2 LTS))
 * Fix failing tests for Django 2.2.
+* Fix failing lint test
 
 
 v1.0.6 - 23/04/2020

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Originally based on: `Django snippet 2484 <http://djangosnippets.org/snippets/24
 Supported versions
 ==================
 
-* Django 3.1, 3.0, 2.2, 2.1, 2.0, 1.11, 1.10, 1.9, 1.8
-* Python 3.8, 3.7, 3.6, 3.5, 3.4, 2.7
+* Django 3.2, 3.1, 3.0, 2.2, 2.1, 2.0, 1.11, 1.10, 1.9, 1.8
+* Python 3.9, 3.8, 3.7, 3.6, 3.5, 3.4, 2.7
 
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
+        'Framework :: Django :: 3.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: ISC License (ISCL)',
         'Natural Language :: English',
@@ -53,5 +54,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-
+from django.core.management.utils import get_random_secret_key
 
 def pytest_configure():
     settings.configure(
@@ -34,4 +34,5 @@ def pytest_configure():
                 ],
             },
         }],
+        SECRET_KEY=get_random_secret_key()
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
-    {py38,py37,py36}-django31,
-    {py38,py37,py36}-django30,
-    {py38,py37,py36,py35}-django22,
+    {py39,py38,py37,py36}-django32,
+    {py39,py38,py37,py36}-django31,
+    {py39,py38,py37,py36}-django30,
+    {py39,py38,py37,py36,py35}-django22,
     {py37,py36,py35}-django21,
     {py37,py36,py35,py34}-django20,
     {py37,py36,py35,py34,py27}-{django111},
@@ -20,6 +21,7 @@ deps =
     django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
     coverage
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3
     django30: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
     coverage


### PR DESCRIPTION
Fixes issue #63 

This PR:
- Adds test for Django 3.2
- Adds tests using Python 3.9 (to Django versions >=2.2)
- Fixes failing tests for Django 3.2 
- Fixes failing `py36-flake8` test, as described in #63 
- Builds on previous work from PR #62 

To get Django 3.2 tests to work, a `SECRET_KEY` (which seems to be a requirement for Django 3.2 to run) had to be defined in `conftest.py` .  The addition of this `SECRET_KEY` also fixes the failing `py36-lint` tests, which are being tested against the latest version of Django (also currently 3.2).

The fix uses the same function (`get_random_secret_key()`) that Django uses to auto-generate `SECRET_KEY`s.